### PR TITLE
Avoid global time changes when sampling mesh frames

### DIFF
--- a/src/demBonesCmd.cpp
+++ b/src/demBonesCmd.cpp
@@ -7,6 +7,8 @@
 #endif
 
 #include <maya/MAnimControl.h>
+#include <maya/MDGContext.h>
+#include <maya/MDGContextGuard.h>
 #include <maya/MDagPath.h>
 #include <maya/MEulerRotation.h>
 #include <maya/MFnAnimCurve.h>
@@ -213,76 +215,74 @@ MStatus DemBonesCmd::readMeshSequence(double startFrame, double endFrame) {
   model_.nB = pathBones_.length();
   model_.m.resize(model_.nF * 4, model_.nB * 4);
 
-  int frameCount = static_cast<int>(endFrame - startFrame + 1);
+  // Get bone info without altering the global time
+  MTime time(0.0);
+  {
+    MDGContextGuard timeGuard(MDGContext(time));
+    model_.boneName.resize(model_.nB);
+    for (unsigned int i = 0; i < model_.nB; ++i) {
+      model_.boneName[i] = pathBones_[i].partialPathName().asChar();
+    }
 
-  // Get bone info
-  MTime time = MAnimControl::currentTime();
-  time.setValue(0.0);
-  status = MAnimControl::setCurrentTime(time);
-  CHECK_MSTATUS_AND_RETURN_IT(status);
-  model_.boneName.resize(model_.nB);
-  for (unsigned int i = 0; i < model_.nB; ++i) {
-    model_.boneName[i] = pathBones_[i].partialPathName().asChar();
-  }
+    model_.parent.resize(model_.nB);
+    model_.bind.resize(model_.nS * 4, model_.nB * 4);
+    model_.preMulInv.resize(model_.nS * 4, model_.nB * 4);
+    model_.rotOrder.resize(model_.nS * 3, model_.nB);
+    int s = 0;
 
-  model_.parent.resize(model_.nB);
-  model_.bind.resize(model_.nS * 4, model_.nB * 4);
-  model_.preMulInv.resize(model_.nS * 4, model_.nB * 4);
-  model_.rotOrder.resize(model_.nS * 3, model_.nB);
-  int s = 0;
+    for (int j = 0; j < model_.nB; j++) {
+      std::string nj = model_.boneName[j];
 
-  for (int j = 0; j < model_.nB; j++) {
-    std::string nj = model_.boneName[j];
-
-    model_.parent(j) = -1;
-    MDagPath parent(pathBones_[j]);
-    status = parent.pop();
-    if (!MFAIL(status)) {
-      for (int k = 0; k < model_.nB; k++) {
-        if (model_.boneName[k] == parent.partialPathName().asChar()) {
-          model_.parent(j) = k;
+      model_.parent(j) = -1;
+      MDagPath parent(pathBones_[j]);
+      status = parent.pop();
+      if (!MFAIL(status)) {
+        for (int k = 0; k < model_.nB; k++) {
+          if (model_.boneName[k] == parent.partialPathName().asChar()) {
+            model_.parent(j) = k;
+          }
         }
       }
+
+      model_.bind.blk4(s, j) = toMatrix4d(pathBones_[j].inclusiveMatrix());
+
+      MFnTransform fnTransform(pathBones_[j], &status);
+      CHECK_MSTATUS_AND_RETURN_IT(status);
+      MEulerRotation rotation;
+      fnTransform.getRotation(rotation);
+      switch (rotation.order) {
+        case MEulerRotation::kXYZ:
+          model_.rotOrder.vec3(s, j) = Eigen::Vector3i(0, 1, 2);
+          break;
+        case MEulerRotation::kYZX:
+          model_.rotOrder.vec3(s, j) = Eigen::Vector3i(1, 2, 0);
+          break;
+        case MEulerRotation::kZXY:
+          model_.rotOrder.vec3(s, j) = Eigen::Vector3i(2, 0, 1);
+          break;
+        case MEulerRotation::kXZY:
+          model_.rotOrder.vec3(s, j) = Eigen::Vector3i(0, 2, 1);
+          break;
+        case MEulerRotation::kYXZ:
+          model_.rotOrder.vec3(s, j) = Eigen::Vector3i(1, 0, 2);
+          break;
+        case MEulerRotation::kZYX:
+          model_.rotOrder.vec3(s, j) = Eigen::Vector3i(2, 1, 0);
+          break;
+      }
+
+      MMatrix preMulInv;  // Seems to always be identity
+      /*MMatrix gp = pathBones_[j].exclusiveMatrix();
+      pathBones_[j].exclusiveMatrixInverse() *
+
+      if (jn[j].pParentJoint == NULL)
+        preMulInv = gp.inverse();
+      else {
+        Matrix4d gjp = Map<Matrix4d>((double*)(jn[j].pParentJoint->EvaluateGlobalTransform()));
+        preMulInv =  gp.inverse() * gjp;
+      }*/
+      model_.preMulInv.blk4(s, j) = toMatrix4d(preMulInv);
     }
-
-    model_.bind.blk4(s, j) = toMatrix4d(pathBones_[j].inclusiveMatrix());
-
-    MFnTransform fnTransform(pathBones_[j], &status);
-    CHECK_MSTATUS_AND_RETURN_IT(status);
-    MEulerRotation rotation;
-    fnTransform.getRotation(rotation);
-    switch (rotation.order) {
-      case MEulerRotation::kXYZ:
-        model_.rotOrder.vec3(s, j) = Eigen::Vector3i(0, 1, 2);
-        break;
-      case MEulerRotation::kYZX:
-        model_.rotOrder.vec3(s, j) = Eigen::Vector3i(1, 2, 0);
-        break;
-      case MEulerRotation::kZXY:
-        model_.rotOrder.vec3(s, j) = Eigen::Vector3i(2, 0, 1);
-        break;
-      case MEulerRotation::kXZY:
-        model_.rotOrder.vec3(s, j) = Eigen::Vector3i(0, 2, 1);
-        break;
-      case MEulerRotation::kYXZ:
-        model_.rotOrder.vec3(s, j) = Eigen::Vector3i(1, 0, 2);
-        break;
-      case MEulerRotation::kZYX:
-        model_.rotOrder.vec3(s, j) = Eigen::Vector3i(2, 1, 0);
-        break;
-    }
-
-    MMatrix preMulInv;  // Seems to always be identity
-    /*MMatrix gp = pathBones_[j].exclusiveMatrix();
-    pathBones_[j].exclusiveMatrixInverse() *
-
-    if (jn[j].pParentJoint == NULL)
-      preMulInv = gp.inverse();
-    else {
-      Matrix4d gjp = Map<Matrix4d>((double*)(jn[j].pParentJoint->EvaluateGlobalTransform()));
-      preMulInv =  gp.inverse() * gjp;
-    }*/
-    model_.preMulInv.blk4(s, j) = toMatrix4d(preMulInv);
   }
 
   // TODO: Use existing bone weight
@@ -302,15 +302,15 @@ MStatus DemBonesCmd::readMeshSequence(double startFrame, double endFrame) {
 
   for (int s = 0; s < model_.nS; s++) {
     int start = model_.fStart(s);
-    // Read vertex data each frame
+    // Read vertex data each frame without changing the global time
     for (int f = 0; f < model_.nF; ++f) {
       double frame = startFrame + static_cast<double>(f);
-      time.setValue(frame);
-      status = MAnimControl::setCurrentTime(time);
-      CHECK_MSTATUS_AND_RETURN_IT(status);
+      MTime frameTime(frame);
       model_.fTime(start + f) = frame;
+
+      MDGContextGuard frameGuard(MDGContext(frameTime));
       MPointArray points;
-      fnMesh.getPoints(points, MSpace::kWorld);
+      fnMesh.getPointsAtTime(points, frameTime, MSpace::kWorld);
 
 #pragma omp parallel for
       for (int i = 0; i < model_.nV; i++) {
@@ -339,15 +339,13 @@ MStatus DemBonesCmd::readMeshSequence(double startFrame, double endFrame) {
 
 MStatus DemBonesCmd::readBindPose() {
   MStatus status;
-  MTime time = MAnimControl::currentTime();
-  time.setValue(0.0);
-  status = MAnimControl::setCurrentTime(time);
-  CHECK_MSTATUS_AND_RETURN_IT(status);
+  MTime time(0.0);
+  MDGContextGuard timeGuard(MDGContext(time));
 
   MFnMesh fnMesh(pathMesh_, &status);
   CHECK_MSTATUS_AND_RETURN_IT(status);
   MPointArray points;
-  fnMesh.getPoints(points, MSpace::kWorld);
+  fnMesh.getPointsAtTime(points, time, MSpace::kWorld);
 
   model_.u.resize(model_.nS * 3, model_.nV);
   Eigen::MatrixXd v;
@@ -471,10 +469,9 @@ MStatus DemBonesCmd::setSkinCluster(const std::vector<std::string>& name,
                                     const Eigen::MatrixXd& gb) {
   MStatus status;
 
-  // Assume neutral is on frame 0
-  MTime time = MAnimControl::currentTime();
-  time.setValue(0.0);
-  MAnimControl::setCurrentTime(time);
+  // Assume neutral is on frame 0 without altering global time
+  MTime time(0.0);
+  MDGContextGuard timeGuard(MDGContext(time));
 
   // Skin a duplicate of the mesh
   MStringArray duplicate;


### PR DESCRIPTION
## Summary
- Use `MDGContextGuard` and `MFnMesh::getPointsAtTime` to sample mesh vertex positions per-frame without changing the global time.
- Apply the same context-based approach for bind-pose and skin-cluster setup to keep evaluation local.

## Testing
- `pytest -q` *(fails: No module named 'maya')*


------
https://chatgpt.com/codex/tasks/task_e_68944d82ffd8832a9b015a01cd4cae60