### PR TITLE
Refine DemBones command code for clean compilation

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,8 @@
 #ifndef CMT_COMMON_H
 #define CMT_COMMON_H
 
+#include <maya/MArrayDataBuilder.h>
+#include <maya/MArrayDataHandle.h>
 #include <maya/MDagPath.h>
 #include <maya/MDoubleArray.h>
 #include <maya/MFloatVectorArray.h>
@@ -9,10 +11,10 @@
 #include <maya/MPoint.h>
 #include <maya/MPointArray.h>
 #include <maya/MString.h>
-#include <map>
-#include <vector>
-#include <set>
 
+#include <map>
+#include <set>
+#include <vector>
 
 MStatus JumpToElement(MArrayDataHandle& hArray, unsigned int index);
 
@@ -23,13 +25,11 @@ MStatus JumpToElement(MArrayDataHandle& hArray, unsigned int index);
 */
 void StartProgress(const MString& title, unsigned int count);
 
-
 /**
   Helper function to increase the progress bar by the specified amount.
   @param[in] step Step amount.
 */
 void StepProgress(int step);
-
 
 /**
   Check if the progress has been cancelled.
@@ -37,12 +37,10 @@ void StepProgress(int step);
 */
 bool ProgressCancelled();
 
-
 /**
   Ends any running progress bar.
 */
 void EndProgress();
-
 
 /**
   Checks if the path points to a shape node.
@@ -51,7 +49,6 @@ void EndProgress();
  */
 bool isShapeNode(MDagPath& path);
 
-
 /**
   Ensures that the given dag path points to a non-intermediate shape node.
   @param[in,out] path Path to a dag node that could be a transform or a shape.
@@ -59,8 +56,7 @@ bool isShapeNode(MDagPath& path);
   @param[in] intermediate true to get the intermediate shape.
   @return MStatus.
  */
-MStatus getShapeNode(MDagPath& path, bool intermediate=false);
-
+MStatus getShapeNode(MDagPath& path, bool intermediate = false);
 
 /**
   Get the MDagPath of an object.
@@ -76,13 +72,11 @@ MStatus getDagPath(const MString& name, MDagPath& path);
  */
 MStatus getDependNode(const MString& name, MObject& oNode);
 
-
 /**
   Delete all intermediate shapes of the given dag path.
   @param[in] path MDagPath.
  */
 MStatus DeleteIntermediateObjects(MDagPath& path);
-
 
 template <typename T>
 struct ThreadData {
@@ -92,22 +86,23 @@ struct ThreadData {
   T* pData;
 };
 
-
 /**
   Creates the data stuctures that will be sent to each thread.  Divides the vertices into
   discrete chunks to be evaluated in the threads.
   @param[in] taskCount The number of individual tasks we want to divide the calculation into.
   @param[in] elementCount The number of vertices or elements to be divided up.
   @param[in] taskData The TaskData or BindData object.
-  @param[out] threadData The array of ThreadData objects.  It is assumed the array is of size taskCount.
+  @param[out] threadData The array of ThreadData objects.  It is assumed the array is of size
+  taskCount.
 */
 template <typename T>
-void CreateThreadData(int taskCount, unsigned int elementCount, T* taskData, ThreadData<T>* threadData) {
+void CreateThreadData(int taskCount, unsigned int elementCount, T* taskData,
+                      ThreadData<T>* threadData) {
   unsigned int taskLength = (elementCount + taskCount - 1) / taskCount;
   unsigned int start = 0;
   unsigned int end = taskLength;
   int lastTask = taskCount - 1;
-  for(int i = 0; i < taskCount; i++) {
+  for (int i = 0; i < taskCount; i++) {
     if (i == lastTask) {
       end = elementCount;
     }

--- a/src/demBonesCmd.cpp
+++ b/src/demBonesCmd.cpp
@@ -21,7 +21,9 @@
 #include <maya/MGlobal.h>
 #include <maya/MMatrix.h>
 #include <maya/MPlug.h>
+#include <maya/MStringArray.h>
 #include <maya/MTime.h>
+#include <maya/MTimeArray.h>
 
 #include <sstream>
 
@@ -337,7 +339,8 @@ MStatus DemBonesCmd::readMeshSequence(Model& model, double startFrame, double en
       MDGContextGuard frameGuard(MDGContext(frameTime));
 
       MPointArray points;
-      fnMesh.getPointsAtTime(points, frameTime, MSpace::kWorld);
+      status = fnMesh.getPoints(points, MSpace::kWorld);
+      CHECK_MSTATUS_AND_RETURN_IT(status);
 
 #pragma omp parallel for
       for (int i = 0; i < model.nV; i++) {
@@ -373,7 +376,8 @@ MStatus DemBonesCmd::readBindPose(Model& model) {
   MFnMesh fnMesh(pathMesh_, &status);
   CHECK_MSTATUS_AND_RETURN_IT(status);
   MPointArray points;
-  fnMesh.getPointsAtTime(points, time, MSpace::kWorld);
+  status = fnMesh.getPoints(points, MSpace::kWorld);
+  CHECK_MSTATUS_AND_RETURN_IT(status);
 
   model.u.resize(model.nS * 3, model.nV);
   Eigen::MatrixXd v;
@@ -390,8 +394,8 @@ MStatus DemBonesCmd::readBindPose(Model& model) {
     MIntArray vertexList;
     fnMesh.getPolygonVertices(i, vertexList);
     model.fv[i].resize(vertexList.length());
-    for (unsigned int j = 0; j < model.fv[i].size(); ++j) {
-      model.fv[i][j] = vertexList[j];
+    for (size_t j = 0; j < model.fv[i].size(); ++j) {
+      model.fv[i][j] = vertexList[static_cast<unsigned int>(j)];
     }
   }
 
@@ -423,14 +427,15 @@ MStatus DemBonesCmd::redoIt() {
           model.computeRTB(s, lr, lt, gb, lbr, lbt, false);
 
           Eigen::VectorXd val;
-          for (int j = 0; j < newBoneNames.size(); ++j) {
+          for (int j = 0; j < static_cast<int>(newBoneNames.size()); ++j) {
             MString name(newBoneNames[j].c_str());
             MString cmd("createNode \"joint\" -n \"" + name + "\"");
             MGlobal::executeCommand(cmd);
           }
-          int startJointIdx =
-              newBoneNames.size() == 0 ? 0 : model.boneName.size() - newBoneNames.size();
-          for (int j = startJointIdx; j < model.boneName.size(); ++j) {
+          int startJointIdx = newBoneNames.empty()
+                                  ? 0
+                                  : static_cast<int>(model.boneName.size() - newBoneNames.size());
+          for (int j = startJointIdx; j < static_cast<int>(model.boneName.size()); ++j) {
             MDagPath pathJoint;
             status = getDagPath(model.boneName[j].c_str(), pathJoint);
             CHECK_MSTATUS_AND_RETURN_IT(status);
@@ -469,8 +474,7 @@ MStatus DemBonesCmd::redoIt() {
 MStatus DemBonesCmd::setKeyframes(const Eigen::VectorXd& val, const Eigen::VectorXd& fTime,
                                   const MDagPath& pathJoint, const MString& attributeName) {
   MStatus status;
-  int idx = 0;
-  int nFr = (int)fTime.size();
+  int nFr = static_cast<int>(fTime.size());
   MFnDagNode fnNode(pathJoint, &status);
   CHECK_MSTATUS_AND_RETURN_IT(status);
   MPlug plug = fnNode.findPlug(attributeName, false, &status);

--- a/src/demBonesCmd.h
+++ b/src/demBonesCmd.h
@@ -15,13 +15,13 @@
 #include "DemBones/DemBonesExt.h"
 
 // Standard library
+#include <Eigen/Core>
+#include <Eigen/Sparse>
 #include <iostream>
 #include <variant>
 
-using namespace Dem;
-
 template <typename AniMeshScalar>
-class MyDemBones : public DemBonesExt<double, AniMeshScalar> {
+class MyDemBones : public Dem::DemBonesExt<double, AniMeshScalar> {
  public:
   void cbIterBegin() { std::cout << "    Iter #" << iter << ": "; }
 


### PR DESCRIPTION
## Summary
- Avoid namespace pollution in `DemBonesCmd` and include required Eigen headers
- Add missing Maya includes and tighten loops and variable usage in `demBonesCmd.cpp`
- Provide necessary Maya array headers in `common.h`
- Replace removed `MFnMesh::getPointsAtTime` with `getPoints` and guard calls with status checks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'maya')*
- `cmake .. -DMAYA_VERSION=2025` *(fails: ❌ 未找到 pluginEntry.cmake：C:/Program Files/Autodesk/Maya2025/cmake/pluginEntry.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68946c95d978832aa4a0ab5a401d6f0c